### PR TITLE
Update dark and light styles for chat entries and message bubbles

### DIFF
--- a/src/style-dark.css
+++ b/src/style-dark.css
@@ -1,0 +1,11 @@
+.chat-entry {
+  background: #024b3049;
+}
+
+.message-bubble-assistant {
+  background-image: linear-gradient(45deg, #024b3050, #024b3030);
+}
+
+.main-box {
+  background-color: #1F2527;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
 .chat-entry {
-  background: #024b3049;
+  background: #fff;
   border-radius: 12px;
 }
 
@@ -13,7 +13,7 @@
 }
 
 .message-bubble-assistant {
-  background-image: linear-gradient(45deg, #024b3050, #024b3030);
+  background-image: linear-gradient(45deg, #8DF1CD50, #8DF1CD30);
 }
 
 .timestamp {
@@ -27,5 +27,5 @@
 }
 
 .main-box {
-  background-color: #1F2527;
+  background-color: #D2FAEB;
 }


### PR DESCRIPTION
<img width="450" height="650" alt="image" src="https://github.com/user-attachments/assets/8c3f08f4-613c-49d9-bb71-ee9918728e28" />

<img width="450" height="650" alt="image" src="https://github.com/user-attachments/assets/55ea2151-1bce-427e-b513-a5a3fe3738a6" />

fixes #25 